### PR TITLE
[EXAMPLES] Call `imshow` with `interpolation=none` in conjunction with `make_grid_with_black_boxes_and_white_background`

### DIFF
--- a/examples/bars-test/viz.py
+++ b/examples/bars-test/viz.py
@@ -71,7 +71,7 @@ class Visualizer(object):
             eps=0.02,
         )
 
-        self._handles["datapoints"] = ax.imshow(np.squeeze(grid))
+        self._handles["datapoints"] = ax.imshow(np.squeeze(grid), interpolation="none")
         ax.axis("off")
 
         self._handles["datapoints"].set_cmap(cmap)
@@ -96,7 +96,7 @@ class Visualizer(object):
         )
 
         if self._handles["W_gen"] is None:
-            self._handles["W_gen"] = ax.imshow(np.squeeze(grid))
+            self._handles["W_gen"] = ax.imshow(np.squeeze(grid), interpolation="none")
             ax.axis("off")
         else:
             self._handles["W_gen"].set_data(np.squeeze(grid))
@@ -122,7 +122,7 @@ class Visualizer(object):
         )
 
         if self._handles["W"] is None:
-            self._handles["W"] = ax.imshow(np.squeeze(grid))
+            self._handles["W"] = ax.imshow(np.squeeze(grid), interpolation="none")
             ax.axis("off")
         else:
             self._handles["W"].set_data(np.squeeze(grid))
@@ -472,7 +472,7 @@ class SSSCVisualizer(Visualizer):
                 marker="o",
                 fillstyle=Line2D.fillStyles[-1],
                 markersize=4,
-                label=r"$\pi_h^{\mathrm{gen}}$",
+                label=r"$\mu_h^{\mathrm{gen}}$",
             )
         else:
             self._handles["mus_gen"].set_xdata(xdata)

--- a/examples/image-denoising/viz.py
+++ b/examples/image-denoising/viz.py
@@ -127,7 +127,7 @@ class Visualizer(object):
 
         gfs = grid.transpose(1, 2, 0) if self._isrgb else np.squeeze(grid)
         if self._handles["gfs"] is None:
-            self._handles["gfs"] = ax.imshow(gfs)
+            self._handles["gfs"] = ax.imshow(gfs, interpolation="none")
             ax.axis("off")
         else:
             self._handles["gfs"].set_data(gfs)

--- a/examples/image-inpainting/viz.py
+++ b/examples/image-inpainting/viz.py
@@ -130,7 +130,7 @@ class Visualizer(object):
 
         gfs = grid.transpose(1, 2, 0) if self._isrgb else np.squeeze(grid)
         if self._handles["gfs"] is None:
-            self._handles["gfs"] = ax.imshow(gfs)
+            self._handles["gfs"] = ax.imshow(gfs, interpolation="none")
             ax.axis("off")
         else:
             self._handles["gfs"].set_data(gfs)


### PR DESCRIPTION
…nt visualizations in examples (to display black surrounding box correctly)