### PR TITLE
[PARALLEL][EXAMPLES] Revise `scatter_to_processes`, `gather_from_proc…

### DIFF
--- a/evo/utils/parallel.py
+++ b/evo/utils/parallel.py
@@ -10,6 +10,7 @@ from mpi4py import MPI
 typemap = {
     np.dtype("float64"): MPI.DOUBLE,
     np.dtype("float32"): MPI.FLOAT,
+    np.dtype("bool"): MPI.BOOL,
     np.dtype("int16"): MPI.SHORT,
     np.dtype("int32"): MPI.INT,
     np.dtype("int64"): MPI.LONG,
@@ -66,57 +67,95 @@ def allmean(my_a, axis=None, dtype=None, out=None, comm=MPI.COMM_WORLD):
         return comm.allreduce(my_sum) / N
 
 
+def bcast_dtype(data, comm=MPI.COMM_WORLD):
+    """Broadcast dtype of data on root rank.
+
+    :param data: Tensor on root rank
+    :type data: np.ndarray
+    :param comm: MPI communication inferface
+    :type comm: mpi4py.MPI.Intracomm
+    :returns: dtype on each rank
+    """
+    ind_dtype = np.empty((1,), dtype=np.uint8)
+    dtypes = list(typemap.keys())
+    if comm.rank == 0:
+        dtype = data.dtype
+        ind_dtype[:] = [*map(str, dtypes)].index(str(dtype))
+    ind_dtype = comm.bcast(ind_dtype)
+    return dtypes[ind_dtype.item()]
+
+
+def get_chunk_dimensions(to_split, no_chunks, axis=0):
+    """Infer chunk dimensions as required as input by comm.Scatterv and comm.Gatherv
+
+    :param to_split: Array to be split along specified axis into specified number of chunks
+    :type to_split: np.ndarray
+    :param no_chunks: Number to chunks
+    :type no_chunks: int
+    :return: (chunk shapes, chunk lenghts, displacements (compare scatter_to_processes))
+    :type return: Tuple[np.ndarray, np.ndarray, np.ndarray]
+
+    Inspired by: https://stackoverflow.com/a/36082684
+
+    Licensed under the Academic Free License version 3.0
+    """
+    chunks = np.array_split(
+        to_split, no_chunks, axis=axis
+    )  # Split input array into specified number of chunks
+
+    split_sizes = []
+    split_shapes = np.empty((len(chunks), np.ndim(to_split)), dtype=int)
+    for i in range(0, len(chunks), 1):
+        split_sizes = np.append(split_sizes, len(chunks[i]))
+        split_shapes[i] = np.array(chunks[i].shape)
+    split_sizes *= np.prod(to_split.shape[1:])
+    displacements = np.insert(np.cumsum(split_sizes), 0, 0)[0:-1]
+
+    return split_shapes.astype(int), split_sizes.astype(int), displacements.astype(int)
+
+
 def scatter_to_processes(to_scatter, comm=MPI.COMM_WORLD):
     """Split data set and scatter chunks to processes
 
-    :param to_scatter: Dataset to be split and scattered; expected on rank 0
+    :param to_scatter: Array to be split and scattered; expected on rank 0
     :type to_scatter: np.ndarray
     :param comm: MPI communication inferface
     :type comm: mpi4py.MPI.Intracomm
-    :return: Data chunks (living on ranks 0, 1, ..., comm.size-1), indices required to gather again
+    :return: Data chunks (living on ranks 0, 1, ..., comm.size-1)
     :type return: np.ndarray
 
     Inspired by: https://stackoverflow.com/a/36082684
 
     Licensed under the Academic Free License version 3.0
     """
-    if comm.rank == 0:
-        chunks = np.array_split(
-            to_scatter, comm.size, axis=0
-        )  # Split input array by the no available cores
-        split_sizes = []
-        split_shapes = np.empty((len(chunks), 2), dtype=int)
-        for i in range(0, len(chunks), 1):
-            split_sizes = np.append(split_sizes, len(chunks[i]))
-            split_shapes[i] = np.array(chunks[i].shape)
-        split_sizes_input = split_sizes * np.prod(to_scatter.shape[1:])
-        displacements_input = np.insert(np.cumsum(split_sizes_input), 0, 0)[0:-1]
-    else:
-        split_shapes = None
-        split_sizes_input = None
-        displacements_input = None
-    split_sizes = comm.bcast(split_sizes_input, root=0).astype(int)
-    split_shapes = comm.bcast(split_shapes, root=0).astype(int)
-    displacements = comm.bcast(displacements_input, root=0).astype(int)
 
-    # Create array to receive  subset of data on each core, where rank specifies + the core
-    chunk = np.zeros(split_shapes[comm.rank])
+    # get split dimensions
+    split_shapes, split_sizes, displacements = (
+        get_chunk_dimensions(to_scatter, comm.size) if comm.rank == 0 else (None, None, None)
+    )
+    split_sizes = comm.bcast(split_sizes, root=0)
+    split_shapes = comm.bcast(split_shapes, root=0)
+    displacements = comm.bcast(displacements, root=0)
+
+    # Create array to receive subset of data on each core, where rank specifies + the core
+    dtype = bcast_dtype(to_scatter)
+    chunk = np.zeros(split_shapes[comm.rank]).astype(dtype)
 
     # Scatter data
-    comm.Scatterv([to_scatter, split_sizes_input, displacements_input, MPI.DOUBLE], chunk, root=0)
+    comm.Scatterv(
+        [to_scatter, split_sizes, displacements, typemap[dtype]],
+        chunk,
+        root=0,
+    )
 
-    return chunk, split_sizes, displacements
+    return chunk
 
 
-def gather_from_processes(chunk, split_sizes, displacements, comm=MPI.COMM_WORLD):
+def gather_from_processes(chunk, comm=MPI.COMM_WORLD):
     """Gather data chunks on rank zero
 
     :param chunk: Data chunks, living on ranks 0, 1, ..., comm.size-1
     :type chunk: np.ndarray
-    :param split_sizes: Chunk lenghts on individual ranks
-    :type split_sizes: np.ndarray
-    :param displacements: Chunk displacements (compare scatter_to_processes)
-    :type displacements: np.ndarray
     :return: Dataset gathered again, living on rank 0
     :type return: np.ndarray
 
@@ -125,7 +164,10 @@ def gather_from_processes(chunk, split_sizes, displacements, comm=MPI.COMM_WORLD
     Licensed under the Academic Free License version 3.0
     """
     comm.Barrier()
+
     total_length = np.array(chunk.shape[0])
-    gathered = np.empty((comm.allreduce(total_length), chunk.shape[1]), dtype=chunk.dtype)
-    comm.Gatherv(chunk, [gathered, split_sizes, displacements, MPI.DOUBLE], root=0)
+    gathered = np.empty((comm.allreduce(total_length), *chunk.shape[1:]), dtype=chunk.dtype)
+    _, split_sizes, displacements = get_chunk_dimensions(gathered, comm.size)
+
+    comm.Gatherv(chunk, [gathered, split_sizes, displacements, typemap[chunk.dtype]], root=0)
     return gathered

--- a/examples/bars-test/main.py
+++ b/examples/bars-test/main.py
@@ -79,9 +79,9 @@ if __name__ == "__main__":
         else {
             "W": args.bar_amp * generate_bars_dict(args.H, neg_bars=args.neg_bars),
             "pies": np.ones(args.H) * pi_gen,
-            "sigma2": np.array(args.sigma_gen ** 2),
+            "sigma2": np.array(args.sigma_gen**2),
             "mus": np.ones(args.H) * args.mu_gen,
-            "Psi": np.eye(args.H) * args.psi_gen ** 2,
+            "Psi": np.eye(args.H) * args.psi_gen**2,
         }
     )
     comm.Barrier()
@@ -95,7 +95,7 @@ if __name__ == "__main__":
 
     # distribute data to MPI processes
     pprint("Scattering data to processes")
-    my_y = scatter_to_processes(Y)[0]
+    my_y = scatter_to_processes(Y)
     my_N = my_y.shape[0]
     my_data = {"y": my_y, "x_infr": np.logical_not(np.isnan(my_y))}
     comm.Barrier()

--- a/examples/bars-test/utils.py
+++ b/examples/bars-test/utils.py
@@ -24,7 +24,7 @@ def generate_bars_dict(H, neg_bars=False):
     https://github.com/ml-uol/prosper/blob/master/LICENSE.txt
     """
     R = H // 2
-    D = R ** 2
+    D = R**2
     W_gt = np.zeros((R, R, H))
     for i in range(R):
         W_gt[i, :, i] = 1.0

--- a/examples/feature-learning/main.py
+++ b/examples/feature-learning/main.py
@@ -96,7 +96,7 @@ if __name__ == "__main__":
 
     # distribute data to MPI processes
     pprint("Scattering data to processes")
-    my_y = scatter_to_processes(Y)[0]
+    my_y = scatter_to_processes(Y)
     my_N = my_y.shape[0]
     my_data = {"y": my_y, "x_infr": np.logical_not(np.isnan(my_y))}
     comm.Barrier()

--- a/examples/image-denoising/main.py
+++ b/examples/image-denoising/main.py
@@ -100,7 +100,7 @@ if __name__ == "__main__":
 
     # distribute data to MPI processes
     pprint("Scattering data to processes")
-    my_y, split_sizes, displacements = scatter_to_processes(Y)
+    my_y = scatter_to_processes(Y)
     my_N = my_y.shape[0]
     my_data = {
         "y": my_y,  # local dataset
@@ -166,11 +166,7 @@ if __name__ == "__main__":
 
         # merge reconstructed image patches and generate reconstructed image
         assert "y_reconstructed" in my_data if do_reconstruction else True
-        Y_rec_T = (
-            gather_from_processes(my_data["y_reconstructed"], split_sizes, displacements).T
-            if do_reconstruction
-            else None
-        )
+        Y_rec_T = gather_from_processes(my_data["y_reconstructed"]).T if do_reconstruction else None
         merge = do_reconstruction and (comm.rank == 0)
         imgs = {
             k: ovp.set_and_merge(Y_rec_T, merge_method=v) if merge else None

--- a/examples/image-inpainting/main.py
+++ b/examples/image-inpainting/main.py
@@ -102,7 +102,7 @@ if __name__ == "__main__":
 
     # distribute data to MPI processes
     pprint("Scattering data to processes")
-    my_y, split_sizes, displacements = scatter_to_processes(Y)
+    my_y = scatter_to_processes(Y)
     my_N = my_y.shape[0]
     my_data = {
         "y": my_y,  # local dataset
@@ -171,11 +171,7 @@ if __name__ == "__main__":
         # merge reconstructed image patches and generate reconstructed image
         gather = e == 0 or (e + 1) % merge_every == 0
         assert "y_reconstructed" in my_data if gather else True
-        Y_rec_T = (
-            gather_from_processes(my_data["y_reconstructed"], split_sizes, displacements).T
-            if gather
-            else None
-        )
+        Y_rec_T = gather_from_processes(my_data["y_reconstructed"]).T if gather else None
         merge = gather and comm.rank == 0
         imgs = {
             k: ovp.set_and_merge(Y_rec_T, merge_method=v) if merge else None


### PR DESCRIPTION
…esses` to correctly handle three- or higher dimensional arrays

* Move computation of chunk dimensions to new method `get_chunk_dimensions`
* New method `bcast_dtype` allows to broadcast dtype from array on root rank
* `scatter_to_processes` does not return chunk dimensions anymore
* `gather_from_processes` does not require chunk dimensions as input anymore
* Adapt usage of `scatter_to_processes` and `gather_from_processes` in examples